### PR TITLE
admin page fix

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -49,17 +49,17 @@ get '/' do
         :locals => {:hello => "Привет, мир!"}   # задаем локальные переменные
 end
 
-# роут для отображения отдельных страниц
-get '/:page_url' do
-  @page = @pages.where(page_url: params[:page_url]).first.to_dot
-  slim  :page,
-        :layout => "layouts/app".to_sym
-end
-
 # роут для админки, закрытый на базовыю HTTP-авторизацию средствами Rack
 get '/admin' do
   # через этот метод закрываем роут на HTTP-авторизацию
   protected!
   slim  :dashboard,
         :layout => "layouts/admin".to_sym
+end
+
+# роут для отображения отдельных страниц
+get '/:page_url' do
+  @page = @pages.where(page_url: params[:page_url]).first.to_dot
+  slim  :page,
+        :layout => "layouts/app".to_sym
 end


### PR DESCRIPTION
/admin must be before /:page_url , because it is more specific
ну и на русском: возникала ошибка, так как /admin тоже подходит под описание /:page_url, но при этом не может нормально интерпретироваться, поэтому этот роут надо поставить выше как более конкретный